### PR TITLE
The framework is considering some of the strings as html even if they…

### DIFF
--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -157,6 +157,9 @@
         CMHTMLElement *element = [self newHTMLElementForTagName:tagName HTML:HTML];
         if (element != nil) {
             [self appendHTMLElement:element];
+        } else {
+            // if user enters non html string(for Example "<test>") this string is treated as html and not able to genearte attributed string for this reason considering the above string as normal text and generating attributed String
+            [self appendString:HTML];
         }
     }
 }


### PR DESCRIPTION
… are not (Example <test>) because of this it is not able to generate attributed strings